### PR TITLE
Add script to clean global types if empty

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -6,7 +6,8 @@
   "author": "Marius Craciunoiu <marius@uplift.ltd>",
   "bin": {
     "src-clean": "./src/src-clean.sh",
-    "gql-clean": "./src/gql-clean.sh"
+    "gql-clean": "./src/gql-clean.sh",
+    "global-types-clean": "./src/global-types-clean.js"
   },
   "files": [
     "src/",

--- a/packages/scripts/src/global-types-clean.js
+++ b/packages/scripts/src/global-types-clean.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const filePath = path.resolve("./src/__generated__/globalTypes.ts");
+
+if (fs.existsSync(filePath)) {
+  const globalTypes = fs.readFileSync(filePath, { encoding: "utf8" });
+
+  if (globalTypes.includes("export")) {
+    console.info("[types-clean] The globalTypes.ts file passes isolatedModules test");
+  } else {
+    console.info("[types-clean] Removed empty globalTypes.ts");
+    fs.unlinkSync(filePath);
+  }
+} else {
+  console.info(`[types-clean] No globalTypes.ts file detected at ${filePath}`);
+}


### PR DESCRIPTION
When we generate a new package using https://github.com/uplift-ltd/uplift-project-template the build fails because the `globalTypes` file generated by codegen is empty and typescript `isolatedModules` setting doesn't like that. This removes the file if there's no export.