### PR TITLE
chore: set noEmit on check-types

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://nexus.uplift.sh/docs/packages/apollo",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/create-nexus-package/fixtures/package.json
+++ b/packages/create-nexus-package/fixtures/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://nexus.uplift.sh/docs/packages/<%= PACKAGE_NAME %>",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {},

--- a/packages/setup-proxy/package.json
+++ b/packages/setup-proxy/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://nexus.uplift.sh/docs/packages/setup-proxy",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/use-after-delay/package.json
+++ b/packages/use-after-delay/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://nexus.uplift.sh/docs/packages/use-after-delay",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {

--- a/packages/use-on-page-scroll/package.json
+++ b/packages/use-on-page-scroll/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://nexus.uplift.sh/docs/packages/use-on-page-scroll",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {

--- a/packages/use-safe-timeout/package.json
+++ b/packages/use-safe-timeout/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://nexus.uplift.sh/docs/packages/use-safe-timeout",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {


### PR DESCRIPTION
Since we use `tsc` to build the packages, `noEmit` is set to false. This passes `--noEmit` to `check-types` to ensure it doesn't write anything to disk.