### PR TITLE
feat: add apollo network status helpers

### DIFF
--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -8,8 +8,12 @@
 
 ### useEnhancedQuery
 
-Same as Apollo useQuery except it accepted a third parameter for setting the auth/unauth endpoints
-for you. Defaults to auth endpoint.
+Same API as Apollo useQuery except:
+
+- It accepts a third parameter for setting the auth/unauth endpoints for you. Defaults to auth
+  endpoint.
+- It returns `initialLoading`, `refetching`, and `fetchingMore` (pass in
+  `notifyOnNetworkStatusChange: true`)
 
 ```ts
 import { useEnhancedQuery } from "@uplift-ltd/apollo";
@@ -18,6 +22,10 @@ useEnhancedQuery<MyQuery, MyQueryVariables>(MY_QUERY, { variables }, { auth: fal
 ```
 
 See [Apollo useQuery docs](https://www.apollographql.com/docs/react/api/react/hooks/#usequery).
+
+```ts
+const { data, initialLoading, refetching, fetchingMore } = useEnhancedQuery(MY_QUERY, { notifyOnNetworkStatusChange: true};
+```
 
 ### useEnhancedLazyQuery
 

--- a/packages/apollo/src/hooks.ts
+++ b/packages/apollo/src/hooks.ts
@@ -4,6 +4,7 @@ import {
   useMutation,
   MutationHookOptions,
   MutationTuple,
+  NetworkStatus,
   OperationVariables,
   QueryHookOptions,
   QueryResult,
@@ -16,18 +17,31 @@ interface ExtraOptions {
   auth?: boolean;
 }
 
+type EnhancedQueryResult<TData, TVariables> = QueryResult<TData, TVariables> & {
+  initialLoading: boolean;
+  refetching: boolean;
+  fetchingMore: boolean;
+};
+
 export function useEnhancedQuery<TData, TVariables = OperationVariables>(
   query: DocumentNode,
   options: QueryHookOptions<TData, TVariables> = {},
   extraOptions: ExtraOptions = { auth: true }
-): QueryResult<TData, TVariables> {
-  return useQuery(query, {
+): EnhancedQueryResult<TData, TVariables> {
+  const result = useQuery(query, {
     ...options,
     context: {
       uri: extraOptions.auth ? GRAPHQL_AUTH_URL : GRAPHQL_UNAUTH_URL,
       ...options.context,
     },
   });
+
+  return {
+    ...result,
+    initialLoading: result.networkStatus === NetworkStatus.loading,
+    refetching: result.networkStatus === NetworkStatus.refetch,
+    fetchingMore: result.networkStatus === NetworkStatus.fetchMore,
+  };
 }
 
 export function useEnhancedLazyQuery<TData, TVariables = OperationVariables>(

--- a/website/docs/packages/apollo.md
+++ b/website/docs/packages/apollo.md
@@ -10,8 +10,12 @@ title: apollo
 
 ### useEnhancedQuery
 
-Same as Apollo useQuery except it accepted a third parameter for setting the auth/unauth endpoints
-for you. Defaults to auth endpoint.
+Same API as Apollo useQuery except:
+
+- It accepts a third parameter for setting the auth/unauth endpoints for you. Defaults to auth
+  endpoint.
+- It returns `initialLoading`, `refetching`, and `fetchingMore` (pass in
+  `notifyOnNetworkStatusChange: true`)
 
 ```ts
 import { useEnhancedQuery } from "@uplift-ltd/apollo";
@@ -20,6 +24,10 @@ useEnhancedQuery<MyQuery, MyQueryVariables>(MY_QUERY, { variables }, { auth: fal
 ```
 
 See [Apollo useQuery docs](https://www.apollographql.com/docs/react/api/react/hooks/#usequery).
+
+```ts
+const { data, initialLoading, refetching, fetchingMore } = useEnhancedQuery(MY_QUERY, { notifyOnNetworkStatusChange: true};
+```
 
 ### useEnhancedLazyQuery
 


### PR DESCRIPTION
Not sure what happens when `notifyOnNetworkStatusChange` is not true, but shouldn't use these in that case.

Closes #33