### PR TITLE
fix: change default keyboard events to be Android friendly

### DIFF
--- a/packages/use-keyboard-visible/src/useKeyboardVisible.ts
+++ b/packages/use-keyboard-visible/src/useKeyboardVisible.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Keyboard } from "react-native";
+import { Keyboard, Platform } from "react-native";
 
 export enum KeyboardShowEvents {
   keyboardWillShow = "keyboardWillShow",
@@ -16,9 +16,16 @@ export interface UseKeyboardVisibleOptions {
   hideEvent?: KeyboardHideEvents;
 }
 
+// Android does not support "will" events, but it's likely better UX for iOS
+const defaultShowEvent =
+  Platform.OS === "ios" ? KeyboardShowEvents.keyboardWillShow : KeyboardShowEvents.keyboardDidShow;
+
+const defaultHideEvent =
+  Platform.OS === "ios" ? KeyboardHideEvents.keyboardWillHide : KeyboardHideEvents.keyboardDidHide;
+
 export function useKeyboardVisible({
-  showEvent = KeyboardShowEvents.keyboardDidShow,
-  hideEvent = KeyboardHideEvents.keyboardDidHide,
+  showEvent = defaultShowEvent,
+  hideEvent = defaultHideEvent,
 }: UseKeyboardVisibleOptions = {}) {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
 


### PR DESCRIPTION
> keyboardWillShow as well as keyboardWillHide are generally not available on Android since there is no native corresponding event.

https://reactnative.dev/docs/keyboard