### PR TITLE
feat: add run number to versions

### DIFF
--- a/packages/constants/src/constants.tsx
+++ b/packages/constants/src/constants.tsx
@@ -1,0 +1,11 @@
+// GraphQL / Apollo constants
+export const GRAPHQL_TOKEN = process.env.REACT_APP_GRAPHQL_TOKEN || "GRAPHQL_TOKEN";
+export const GRAPHQL_HOST = process.env.REACT_APP_GRAPHQL_HOST || "http://localhost:5000";
+export const GRAPHQL_BATCHING = process.env.REACT_APP_GRAPHQL_BATCHING !== "false";
+
+export const GRAPHQL_AUTH_ENDPOINT = GRAPHQL_BATCHING ? "/batch/auth/graphql/" : "/auth/graphql/";
+export const GRAPHQL_UNAUTH_ENDPOINT = GRAPHQL_BATCHING ? "/batch/graphql/" : "/graphql/";
+
+// GitHub Actions
+export const GITHUB_SHA = process.env.GITHUB_SHA || "";
+export const GITHUB_RUN_NUMBER = process.env.GITHUB_RUN_NUMBER || "";

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,9 +1,1 @@
-// GraphQL / Apollo constants
-export const GRAPHQL_TOKEN = process.env.REACT_APP_GRAPHQL_TOKEN || "GRAPHQL_TOKEN";
-export const GRAPHQL_HOST = process.env.REACT_APP_GRAPHQL_HOST || "http://localhost:5000";
-export const GRAPHQL_BATCHING = process.env.REACT_APP_GRAPHQL_BATCHING !== "false";
-
-export const GRAPHQL_AUTH_ENDPOINT = GRAPHQL_BATCHING ? "/batch/auth/graphql/" : "/auth/graphql/";
-export const GRAPHQL_UNAUTH_ENDPOINT = GRAPHQL_BATCHING ? "/batch/graphql/" : "/graphql/";
-
-export const GITHUB_SHA = process.env.GITHUB_SHA || "";
+export * from "./constants";

--- a/packages/react-native-debug/src/Info.tsx
+++ b/packages/react-native-debug/src/Info.tsx
@@ -1,5 +1,5 @@
 import { StackScreenProps } from "@react-navigation/stack";
-import { GITHUB_SHA, GRAPHQL_HOST } from "@uplift-ltd/constants";
+import { GITHUB_SHA, GITHUB_RUN_NUMBER, GRAPHQL_HOST } from "@uplift-ltd/constants";
 import Constants from "expo-constants";
 import { makeUrl } from "expo-linking";
 import { fetchUpdateAsync, releaseChannel, reloadAsync, updateId } from "expo-updates";
@@ -15,6 +15,10 @@ export const Info: React.FC<InfoProps> = () => {
   return (
     <>
       <InfoItem label="Commit" value={GITHUB_SHA} />
+      <InfoItem
+        label="Versions"
+        value={`${Constants.nativeAppVersion} (${Constants.nativeBuildVersion}) - #${GITHUB_RUN_NUMBER} - Expo ${Constants.expoVersion}`}
+      />
       <InfoItem label="GQL Host" value={GRAPHQL_HOST} />
       <InfoItem label="Experience Id" value={Constants.manifest.id} />
       <InfoItem
@@ -28,10 +32,6 @@ export const Info: React.FC<InfoProps> = () => {
       <InfoItem label="Release Channel" value={releaseChannel} />
       <InfoItem label="Slug" value={Constants.manifest.slug} />
       <InfoItem label="Linking Prefix" value={makeUrl("/")} />
-      <InfoItem
-        label="Versions"
-        value={`${Constants.nativeAppVersion} (${Constants.nativeBuildVersion}) - ${Constants.expoVersion}`}
-      />
       <InfoItem label="Installation ID" value={Constants.installationId} />
       {Constants.deviceId !== Constants.installationId && (
         <InfoItem label="Installation ID" value={Constants.deviceId} />


### PR DESCRIPTION
The run number starts from 1 for each workflow and increments with each run (but not re-runs).

It's useful for versioning vs commit id because we can say which run number includes a change and all the run numbers higher than that should include it as well.