### PR TITLE
fix: forward verifyScreen param to magic login screen

### DIFF
--- a/packages/react-native-debug/src/Navigator.tsx
+++ b/packages/react-native-debug/src/Navigator.tsx
@@ -28,7 +28,7 @@ export const DebugNavigator: React.FC<DebugNavigatorProps> = ({ route }) => {
         name={DebugScreens.DEBUG_MAGIC_LOGIN}
         component={MagicLogin}
         options={{ title: "Magic Login" }}
-        initialParams={{}}
+        initialParams={{ verifyScreen: route.params.verifyScreen }}
       />
       <DebugStackNavigator.Screen
         name={DebugScreens.DEBUG_PUSH_TOKEN}


### PR DESCRIPTION
Sugar was using the default value so I didn't notice this wasn't working.