### PR TITLE
fix: Handle arrays in safeJoin

### DIFF
--- a/packages/strings/src/index.ts
+++ b/packages/strings/src/index.ts
@@ -16,6 +16,7 @@ const isStringOrNumber = (variableToCheck: unknown): variableToCheck is string |
 // safeJoin :: String -> [a] -> String
 export const safeJoin = (delimiter: string) => (...xs: unknown[]) =>
   xs
+    .flat()
     .filter(isStringOrNumber)
     .map((x) => {
       if (typeof x === "number") {


### PR DESCRIPTION
Fixes issue with `applyErrorsToFields` where it supplies a single array arg instead of multiple strings.