### PR TITLE
fix: user context unauth

### DIFF
--- a/packages/use-user-context/README.md
+++ b/packages/use-user-context/README.md
@@ -11,17 +11,11 @@
 ```tsx
 import { gql } from "@uplift-ltd/apollo";
 import { UserContextProvider } from "@uplift-ltd/use-user-context";
-import { Authenticated } from "./__generated__/Authenticated";
 import { CurrentUser } from "./__generated__/CurrentUser";
-
-const AUTHENTICATED_QUERY = gql`
-  query Authenticated {
-    isAuthenticated
-  }
-`;
 
 const CURRENT_USER_QUERY = gql`
   query CurrentUser {
+    isAuthenticated
     currentUser: me {
       id
       email
@@ -31,11 +25,7 @@ const CURRENT_USER_QUERY = gql`
 
 function MyApp() {
   return (
-    <UserContextProvider<Authenticated, CurrentUser>
-      getToken={getToken}
-      authenticatedQuery={AUTHENTICATED_QUERY}
-      currentUserQuery={CURRENT_USER_QUERY}
-    >
+    <UserContextProvider<CurrentUser> getToken={getToken} currentUserQuery={CURRENT_USER_QUERY}>
       <div />
     </UserContextProvider>
   );

--- a/packages/use-user-context/src/provider.tsx
+++ b/packages/use-user-context/src/provider.tsx
@@ -4,44 +4,34 @@ import React, { useEffect } from "react";
 import { UserContext } from "./context";
 import { CurrentUserShape } from "./types";
 
-interface AuthenticatedQueryShape {
-  isAuthenticated: boolean;
-}
-
 interface CurrentUserQueryShape {
+  isAuthenticated: boolean;
   currentUser: CurrentUserShape | null;
 }
 
 interface UserContextProviderProps {
   children: React.ReactNode;
-  authenticatedQuery: DocumentNode;
   currentUserQuery: DocumentNode;
   skip?: boolean;
 }
 
-export function UserContextProvider<
-  AuthenticatedQueryResult extends AuthenticatedQueryShape,
-  CurrentUserQueryResult extends CurrentUserQueryShape
->({ children, authenticatedQuery, currentUserQuery, skip = false }: UserContextProviderProps) {
-  const {
-    loading: authenticatedLoading,
-    error: authenticatedError,
-    data: authenticatedData,
-  } = useEnhancedQuery<AuthenticatedQueryResult>(authenticatedQuery, {}, { auth: false });
+export function UserContextProvider<CurrentUserQueryResult extends CurrentUserQueryShape>({
+  children,
+  currentUserQuery,
+  skip = false,
+}: UserContextProviderProps) {
+  const { loading, error, data } = useEnhancedQuery<CurrentUserQueryResult>(
+    currentUserQuery,
+    {
+      skip,
+    },
+    {
+      auth: false,
+    }
+  );
 
-  const {
-    loading: currentUserLoading,
-    error: currentUserError,
-    data: currentUserData,
-  } = useEnhancedQuery<CurrentUserQueryResult>(currentUserQuery, {
-    skip,
-  });
-
-  const loading = authenticatedLoading || currentUserLoading;
-  const error = authenticatedError || currentUserError;
-
-  const isAuthenticated = authenticatedData ? authenticatedData.isAuthenticated : false;
-  const currentUser = currentUserData ? currentUserData.currentUser : null;
+  const isAuthenticated = data ? data.isAuthenticated : false;
+  const currentUser = data ? data.currentUser : null;
 
   useEffect(() => {
     if (currentUser) {

--- a/website/docs/packages/use-user-context.md
+++ b/website/docs/packages/use-user-context.md
@@ -13,17 +13,11 @@ title: use-user-context
 ```tsx
 import { gql } from "@uplift-ltd/apollo";
 import { UserContextProvider } from "@uplift-ltd/use-user-context";
-import { Authenticated } from "./__generated__/Authenticated";
 import { CurrentUser } from "./__generated__/CurrentUser";
-
-const AUTHENTICATED_QUERY = gql`
-  query Authenticated {
-    isAuthenticated
-  }
-`;
 
 const CURRENT_USER_QUERY = gql`
   query CurrentUser {
+    isAuthenticated
     currentUser: me {
       id
       email
@@ -33,11 +27,7 @@ const CURRENT_USER_QUERY = gql`
 
 function MyApp() {
   return (
-    <UserContextProvider<Authenticated, CurrentUser>
-      getToken={getToken}
-      authenticatedQuery={AUTHENTICATED_QUERY}
-      currentUserQuery={CURRENT_USER_QUERY}
-    >
+    <UserContextProvider<CurrentUser> getToken={getToken} currentUserQuery={CURRENT_USER_QUERY}>
       <div />
     </UserContextProvider>
   );


### PR DESCRIPTION
It needs to hit the unauth endpoint otherwise we get a 403. The other option is to skip if authenticated query doesn't return true, but that requires 2 network requests. Getting rid of the separate query since they both hit the same endpoint now. Not making it a breaking chance since nothing is using it yet.