### PR TITLE
fix: file-uploads constants dependency version

### DIFF
--- a/packages/file-uploads/package.json
+++ b/packages/file-uploads/package.json
@@ -29,12 +29,12 @@
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {
-    "@uplift-ltd/constants": "^1.4.0",
     "expo-file-system": "^10.0.0",
     "react": "^16.0.0",
     "react-native": "*"
   },
   "dependencies": {
+    "@uplift-ltd/constants": "^1.5.0",
     "axios": "^0.21.1",
     "lodash": "^4.17.20",
     "mime": "^2.5.2"


### PR DESCRIPTION
It seems lerna doesn't bump peerDependencies automatically. Also we list nexus-codependencies as dependencies for other packages.