### PR TITLE
feat: enhance mapNodes with ability to take node transform callback

### DIFF
--- a/packages/graphene/README.md
+++ b/packages/graphene/README.md
@@ -83,3 +83,14 @@ const nodes = mapNodes(connection);
 
 console.log(nodes); // => [{ id: 1}]
 ```
+
+Optionally takes in a transform callback which will operate on each node,
+
+```js
+import { mapNodes } from "@uplift-ltd/graphene";
+
+const connection = { edges: [{ node: { id: 1 } }] };
+const nodes = mapNodes(connection, (node) => ({ ...node, type: "EnhancedNode" }));
+
+console.log(nodes); // => [{ id: 1, type: "EnhancedNode" }]
+```

--- a/packages/graphene/__tests__/mapNodes.test.ts
+++ b/packages/graphene/__tests__/mapNodes.test.ts
@@ -6,4 +6,11 @@ describe("mapNodes", () => {
     const nodes = mapNodes(connection);
     expect(nodes).toEqual([{ id: 1 }]);
   });
+
+  it("should apply transform callback to each node", () => {
+    const connection = { edges: [{ node: { id: 1 } }] };
+    const nodes = mapNodes(connection, (node) => ({ ...node, type: "EnhancedNode" }));
+
+    expect(nodes).toEqual([{ id: 1, type: "EnhancedNode" }]);
+  });
 });

--- a/packages/graphene/src/mapNodes.ts
+++ b/packages/graphene/src/mapNodes.ts
@@ -6,6 +6,22 @@ interface Connection<T> {
   edges: (Edge<T> | null)[];
 }
 
-export function mapNodes<T>(connection: Connection<T> | null | undefined): T[] {
-  return connection?.edges.filter((edge): edge is Edge<T> => !!edge).map(({ node }) => node) || [];
+export function mapNodes<Node>(connection: Connection<Node> | null | undefined): Node[];
+
+export function mapNodes<Result extends unknown, Node>(
+  connection: Connection<Node> | null | undefined,
+  callback: (node: Node) => Result
+): Result[];
+
+export function mapNodes<Node, Result extends unknown = Node>(
+  connection: Connection<Node> | null | undefined,
+  callback?: (item: Node) => Result
+) {
+  const edges = (connection?.edges || []).filter((edge): edge is Edge<Node> => !!edge);
+
+  if (callback) {
+    return edges.map(({ node }) => callback(node));
+  }
+
+  return edges.map(({ node }) => node);
 }

--- a/website/docs/packages/graphene.md
+++ b/website/docs/packages/graphene.md
@@ -85,3 +85,14 @@ const nodes = mapNodes(connection);
 
 console.log(nodes); // => [{ id: 1}]
 ```
+
+Optionally takes in a transform callback which will operate on each node,
+
+```js
+import { mapNodes } from "@uplift-ltd/graphene";
+
+const connection = { edges: [{ node: { id: 1 } }] };
+const nodes = mapNodes(connection, (node) => ({ ...node, type: "EnhancedNode" }));
+
+console.log(nodes); // => [{ id: 1, type: "EnhancedNode" }]
+```


### PR DESCRIPTION
Add transformCallback param to allow transforming during the map loop, this will remove an additional loop when needing to augment data

```tsx
// before
mapNodes(edges).map(enhanceNode);

// after
mapNodes(edges, enhanceNode);
```
