### PR TITLE
fix: sentry version and export CaptureContext

### DIFF
--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -32,9 +32,9 @@
     "sentry-expo": "^4.0.3"
   },
   "dependencies": {
-    "@sentry/browser": "^6.13.3",
-    "@sentry/node": "^6.13.3",
-    "@sentry/react": "^6.13.3"
+    "@sentry/browser": "^6.12.0",
+    "@sentry/node": "^6.12.0",
+    "@sentry/react": "^6.12.0"
   },
   "devDependencies": {
     "sentry-expo": "^4.0.3"

--- a/packages/sentry/src/browser.ts
+++ b/packages/sentry/src/browser.ts
@@ -9,3 +9,6 @@ if (SENTRY_DSN) {
 }
 
 export default Sentry;
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+export type { CaptureContext } from "@sentry/types";

--- a/packages/sentry/src/constants.ts
+++ b/packages/sentry/src/constants.ts
@@ -8,3 +8,6 @@ export const SENTRY_DSN =
 export const NORMALIZE_DEPTH = Number(
   process.env.SENTRY_NORMALIZE_DEPTH || process.env.NEXT_PUBLIC_SENTRY_NORMALIZE_DEPTH || 10
 );
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+export type { CaptureContext } from "@sentry/types";

--- a/packages/sentry/src/index.native.ts
+++ b/packages/sentry/src/index.native.ts
@@ -11,3 +11,6 @@ if (SENTRY_DSN) {
 }
 
 export default Sentry;
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+export type { CaptureContext } from "@sentry/types";

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -9,3 +9,6 @@ if (SENTRY_DSN) {
 }
 
 export default Sentry;
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+export type { CaptureContext } from "@sentry/types";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,7 +3018,7 @@
     "@sentry/utils" "6.12.0"
     tslib "^1.9.3"
 
-"@sentry/browser@6.13.3", "@sentry/browser@^6.12.0", "@sentry/browser@^6.13.3":
+"@sentry/browser@6.13.3", "@sentry/browser@^6.12.0":
   version "6.13.3"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.13.3.tgz#d4511791b1e484ad48785eba3bce291fdf115c1e"
   integrity sha512-jwlpsk2/u1cofvfYsjmqcnx50JJtf/T6HTgdW+ih8+rqWC5ABEZf4IiB/H+KAyjJ3wVzCOugMq5irL83XDCfqQ==
@@ -3118,7 +3118,7 @@
     "@sentry/types" "6.13.3"
     tslib "^1.9.3"
 
-"@sentry/node@^6.13.3":
+"@sentry/node@^6.12.0":
   version "6.13.3"
   resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.13.3.tgz#94c646c31fd240ab68ee8b85aa663e65eb499d06"
   integrity sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==
@@ -3160,7 +3160,7 @@
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/react@^6.13.3":
+"@sentry/react@^6.12.0":
   version "6.13.3"
   resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.13.3.tgz#f9607e0a60d52efd0baa96a14e694b6059f9379a"
   integrity sha512-fdfmD9XNpGDwdkeLyd+iq+kqtNeghpH3wiez2rD81ZBvrn70uKaO2/yYDE71AXC6fUOwQuJmdfAuqBcNJkYIEw==


### PR DESCRIPTION
`sentry-expo` depends on `@sentry/react-native` and `@sentry/react-native ` depends on `6.12.0` of stuff for some annoying reason. Hopefully this allows projects to install only one version. Also exporting `CaptureContext` because I was getting a type error trying to use `Scope` because there are 2 versions of that, one in in `@sentry/types` and one it seems in `@sentry/hub`.