### PR TITLE
feat: add user context refetch

### DIFF
--- a/packages/use-user-context/src/context.ts
+++ b/packages/use-user-context/src/context.ts
@@ -1,4 +1,4 @@
-import { ApolloError } from "@uplift-ltd/apollo";
+import { ApolloError, ApolloQueryResult, NetworkStatus } from "@uplift-ltd/apollo";
 import { createContext } from "react";
 import { CurrentUserShape } from "./types";
 
@@ -7,10 +7,20 @@ export interface UserContextShape<CurrentUser extends CurrentUserShape = any> {
   error?: ApolloError;
   isAuthenticated: boolean;
   currentUser: CurrentUser | null;
+  refetch(): Promise<ApolloQueryResult<CurrentUser>>;
+  refetching: boolean;
 }
 
 export const UserContext = createContext<UserContextShape>({
   loading: true,
   isAuthenticated: false,
   currentUser: null,
+  refetch: async () => {
+    return {
+      data: null,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+    };
+  },
+  refetching: false,
 });

--- a/packages/use-user-context/src/provider.tsx
+++ b/packages/use-user-context/src/provider.tsx
@@ -20,7 +20,7 @@ export function UserContextProvider<CurrentUserQueryResult extends CurrentUserQu
   currentUserQuery,
   skip = false,
 }: UserContextProviderProps) {
-  const { loading, error, data } = useEnhancedQuery<CurrentUserQueryResult>(
+  const { loading, error, data, refetch, refetching } = useEnhancedQuery<CurrentUserQueryResult>(
     currentUserQuery,
     {
       skip,
@@ -43,7 +43,9 @@ export function UserContextProvider<CurrentUserQueryResult extends CurrentUserQu
   }, [currentUser]);
 
   return (
-    <UserContext.Provider value={{ loading, error, isAuthenticated, currentUser }}>
+    <UserContext.Provider
+      value={{ loading, error, isAuthenticated, currentUser, refetch, refetching }}
+    >
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
Discovered in Design City that refetch queries is tricky to use in some cases because we don't throw an error on login for invalid password.