### PR TITLE
fix(file-uploads): fix file uploads state sync

### DIFF
--- a/packages/file-uploads/src/useUploadFiles.ts
+++ b/packages/file-uploads/src/useUploadFiles.ts
@@ -84,7 +84,16 @@ export function useUploadFiles<FileType = File, UploadResultData = unknown, Uplo
         });
       }
     });
-  }, [fileUploadsState, fileAttachments]);
+    fileUploadsState.fileAttachments.forEach((fileAttachment) => {
+      if (!fileAttachments?.includes(fileAttachment)) {
+        fileUploadsDispatch({
+          type: "REMOVE_FILE",
+          fileAttachmentId: fileAttachment.id,
+        });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileAttachments]);
 
   const { uploadFile } = useUploadFile<UploadType>(uploadFileOptions);
 


### PR DESCRIPTION
On runbook we noticed that removing a file is broken because it re-updates with the old value passed in. This seems to fix it... hope it doesn't break something else.