### PR TITLE
fix(file-uploads): fix uploadFiles metadata type

### DIFF
--- a/packages/file-uploads/src/types.ts
+++ b/packages/file-uploads/src/types.ts
@@ -45,4 +45,6 @@ export interface UploadFileOptions<FileType = File>
 export interface UploadFilesOptions<FileType = File>
   extends GetSignedRequestMutationProvidedVariables {
   files: FileType[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  metadata?: any;
 }


### PR DESCRIPTION
We json stringify so the type shouldn't be string. We already override for single file upload function.