### PR TITLE
fix: Update safeJsonParse types

### DIFF
--- a/packages/strings/src/safeParse.ts
+++ b/packages/strings/src/safeParse.ts
@@ -1,9 +1,21 @@
 export type JsonParseReviverCallback = Parameters<typeof JSON.parse>[1];
+
+export function safeJsonParse<Shape extends unknown>(jsonStr: string): Shape | undefined;
+export function safeJsonParse<Shape extends unknown>(
+  jsonStr: string,
+  fallback: null | undefined,
+  reviver: JsonParseReviverCallback
+): Shape | undefined;
+export function safeJsonParse<Shape extends unknown>(
+  jsonStr: string,
+  fallback: Shape,
+  reviver?: JsonParseReviverCallback
+): Shape;
 export function safeJsonParse<Shape extends unknown>(
   jsonStr: string,
   fallback?: Shape,
   reviver?: JsonParseReviverCallback
-): Shape | undefined {
+) {
   try {
     return JSON.parse(jsonStr, reviver);
   } catch (err) {


### PR DESCRIPTION
make safeJson types a bit tighter