### PR TITLE
feat: add isReady to useRouterQuery and make update stable

### DIFF
--- a/packages/nextjs-use-react-navigation/src/useRouterNavigation.ts
+++ b/packages/nextjs-use-react-navigation/src/useRouterNavigation.ts
@@ -2,7 +2,10 @@ import { useRouter } from "next/router";
 import type { NextRouter } from "next/router";
 import { useRef, useState } from "react";
 
-type RouterNavigationMethods = Pick<NextRouter, "back" | "push" | "reload" | "replace" | "events">;
+type RouterNavigationMethods = Pick<
+  NextRouter,
+  "asPath" | "pathname" | "isReady" | "query" | "back" | "push" | "reload" | "replace" | "events"
+>;
 
 /**
  * useRouter doesn't return stable navigation methods, this gives us something
@@ -19,6 +22,18 @@ export const useRouterNavigation = (): RouterNavigationMethods => {
   routerRef.current = router;
 
   const [routerNavigation] = useState<RouterNavigationMethods>({
+    get asPath() {
+      return routerRef.current.asPath;
+    },
+    get pathname() {
+      return routerRef.current.pathname;
+    },
+    get isReady() {
+      return routerRef.current.isReady;
+    },
+    get query() {
+      return routerRef.current.query;
+    },
     back: (...args) => routerRef.current.back(...args),
     push: (...args) => routerRef.current.push(...args),
     reload: (...args) => routerRef.current.reload(...args),

--- a/packages/nextjs-use-react-navigation/src/useRouterQuery.ts
+++ b/packages/nextjs-use-react-navigation/src/useRouterQuery.ts
@@ -1,6 +1,6 @@
 import { makeQueryString, QueryStringParametersMap, UrlTokens } from "@uplift-ltd/strings";
-import { useRouter } from "next/router";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
+import { useRouterNavigation } from "./useRouterNavigation";
 
 // prettier-ignore
 export type RouterQueryResult<QueryStringParams extends never | string | Record<string, unknown> = never, Tokens extends never | string = never> =
@@ -19,24 +19,24 @@ export function useRouterQuery<
   QueryResult = RouterQueryResult<QueryStringShape>,
   UpdateQueryShape = Partial<[QueryStringShape] extends [string] ? QueryResult : QueryStringShape>
 >() {
-  const router = useRouter();
-  const routerRef = useRef(router);
+  const routerNavigation = useRouterNavigation();
 
-  routerRef.current = router;
+  const updateRouterQuery = useCallback(
+    (newQuery: UpdateQueryShape) => {
+      const q = makeQueryString({ ...routerNavigation.query, ...newQuery });
 
-  const updateRouterQuery = useCallback((newQuery: UpdateQueryShape) => {
-    const q = makeQueryString({ ...routerRef.current.query, ...newQuery });
-
-    if (q) {
-      routerRef.current.replace(`${routerRef.current.pathname}?${q}`);
-    } else {
-      routerRef.current.replace(routerRef.current.pathname);
-    }
-  }, []);
+      if (q) {
+        routerNavigation.replace(`${routerNavigation.pathname}?${q}`);
+      } else {
+        routerNavigation.replace(routerNavigation.pathname);
+      }
+    },
+    [routerNavigation]
+  );
 
   return {
-    isReady: router.isReady,
-    routerQuery: (router.query as unknown) as QueryResult,
+    isReady: routerNavigation.isReady,
+    routerQuery: (routerNavigation.query as unknown) as QueryResult,
     updateRouterQuery,
   };
 }


### PR DESCRIPTION
> isReady: boolean - Whether the router fields are updated client-side and ready for use. Should only be used inside of useEffect methods and not for conditionally rendering on the server. See related docs for use case with [automatically statically optimized pages](https://nextjs.org/docs/advanced-features/automatic-static-optimization)

https://nextjs.org/docs/api-reference/next/router#router-object

On marketing site we were getting an error for contact submission query id being undefined. This adds isReady to skip stuff if needed.