### PR TITLE
feat: add sentry environment to init

### DIFF
--- a/packages/sentry-react-native/src/constants.ts
+++ b/packages/sentry-react-native/src/constants.ts
@@ -1,1 +1,1 @@
-export { NORMALIZE_DEPTH, SENTRY_DSN } from "@uplift-ltd/sentry";
+export { NORMALIZE_DEPTH, SENTRY_DSN, SENTRY_ENVIRONMENT } from "@uplift-ltd/sentry";

--- a/packages/sentry-react-native/src/index.native.ts
+++ b/packages/sentry-react-native/src/index.native.ts
@@ -1,11 +1,12 @@
 import { init } from "sentry-expo";
-import { NORMALIZE_DEPTH, SENTRY_DSN } from "./constants";
+import { NORMALIZE_DEPTH, SENTRY_DSN, SENTRY_ENVIRONMENT } from "./constants";
 
 if (SENTRY_DSN) {
   init({
     dsn: SENTRY_DSN,
     normalizeDepth: NORMALIZE_DEPTH,
     enableInExpoDevelopment: typeof __DEV__ !== "undefined",
+    environment: SENTRY_ENVIRONMENT,
     debug: typeof __DEV__ !== "undefined",
   });
 }

--- a/packages/sentry/src/browser.ts
+++ b/packages/sentry/src/browser.ts
@@ -1,10 +1,11 @@
 import { init } from "@sentry/browser";
-import { NORMALIZE_DEPTH, SENTRY_DSN } from "./constants";
+import { NORMALIZE_DEPTH, SENTRY_DSN, SENTRY_ENVIRONMENT } from "./constants";
 
 if (SENTRY_DSN) {
   init({
     dsn: SENTRY_DSN,
     normalizeDepth: NORMALIZE_DEPTH,
+    environment: SENTRY_ENVIRONMENT,
   });
 }
 

--- a/packages/sentry/src/constants.ts
+++ b/packages/sentry/src/constants.ts
@@ -8,3 +8,6 @@ export const SENTRY_DSN =
 export const NORMALIZE_DEPTH = Number(
   process.env.SENTRY_NORMALIZE_DEPTH || process.env.NEXT_PUBLIC_SENTRY_NORMALIZE_DEPTH || 10
 );
+
+export const SENTRY_ENVIRONMENT =
+  process.env.SENTRY_ENVIRONMENT || process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -1,10 +1,11 @@
 import { init } from "@sentry/node";
-import { NORMALIZE_DEPTH, SENTRY_DSN } from "./constants";
+import { NORMALIZE_DEPTH, SENTRY_DSN, SENTRY_ENVIRONMENT } from "./constants";
 
 if (SENTRY_DSN) {
   init({
     dsn: SENTRY_DSN,
     normalizeDepth: NORMALIZE_DEPTH,
+    environment: SENTRY_ENVIRONMENT,
   });
 }
 


### PR DESCRIPTION
It scares me to see production in these notifications:
<img width="721" alt="Screen Shot 2022-05-06 at 11 49 29 PM" src="https://user-images.githubusercontent.com/465310/167240844-43224bea-beea-437c-9157-550267c11963.png">

Maybe we're supposed to use a single DSN and different envs?