### PR TITLE
fix: Querystring double encoding

### DIFF
--- a/packages/nextjs-use-react-navigation/src/useRouterQuery.ts
+++ b/packages/nextjs-use-react-navigation/src/useRouterQuery.ts
@@ -1,8 +1,4 @@
-import {
-  makeQueryString,
-  QueryStringParametersMap,
-  MultipleUrlsTokensMap,
-} from "@uplift-ltd/strings";
+import { QueryStringParametersMap, MultipleUrlsTokensMap } from "@uplift-ltd/strings";
 import { useCallback } from "react";
 import { useRouterNavigation } from "./useRouterNavigation";
 
@@ -47,13 +43,13 @@ export function useRouterQuery<
 
   const updateRouterQuery = useCallback(
     (newQuery: UpdateQueryShape) => {
-      const q = makeQueryString({ ...routerNavigation.query, ...newQuery });
-
-      if (q) {
-        routerNavigation.replace(`${routerNavigation.pathname}?${q}`);
-      } else {
-        routerNavigation.replace(routerNavigation.pathname);
-      }
+      routerNavigation.replace({
+        pathname: routerNavigation.pathname,
+        query: {
+          ...routerNavigation.query,
+          ...newQuery,
+        },
+      });
     },
     [routerNavigation]
   );

--- a/packages/strings/__tests__/urls.test.ts
+++ b/packages/strings/__tests__/urls.test.ts
@@ -45,6 +45,13 @@ test.each([
     { trailingSlash: "remove" },
     "/test-url/654",
   ],
+  [
+    "/test-url/:tokenId/",
+    { tokenId: "VGFza2xpc3Q6OTI=" },
+    undefined,
+    { trailingSlash: "remove" },
+    "/test-url/VGFza2xpc3Q6OTI=",
+  ],
   ["/test-url/:tokenId", { tokenId: "654" }, undefined, undefined, "/test-url/654"],
   ["/test-url/:tokenId", { tokenId: 123 }, undefined, undefined, "/test-url/123"],
   ["/test-url/:tokenId", { tokenId: 123 }, { msg: "Hello" }, undefined, "/test-url/123?msg=Hello"],
@@ -106,6 +113,13 @@ test.each([
     { msg: "Hello", null: null, undefined },
     { trailingSlash: "remove" },
     "/test-url/987/ABC123?msg=Hello",
+  ],
+  [
+    "/test-url/:tokenId/:userId/",
+    { tokenId: "VGFza2xpc3Q6OTI=", userId: "ABC123" },
+    { msg: "Hello", null: null, id: "VGFza2xpc3Q6OTI=" },
+    { trailingSlash: "remove" },
+    "/test-url/VGFza2xpc3Q6OTI=/ABC123?msg=Hello&id=VGFza2xpc3Q6OTI%3D",
   ],
 ])("makeUrls (%s, %s, %s, %s)", (url, tokens, params, options, expected) => {
   // @ts-expect-error: tokens will complain because some of the provided URLs won't have tokens


### PR DESCRIPTION
The way next.js works is that it treats all URL params as `query` params and then shuffles them into/out of the pathname and search. Because of this, we were passing all params through our QueryString factory which was encoding them as URIComponents, which is great for search params, not so much for URL tokens/params