### PR TITLE
feat: Node 17+/ipv6 support

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -164,7 +164,7 @@ module.exports = {
   // testRunner: "jasmine2",
 
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-  // testURL: "http://localhost",
+  // testURL: "http://127.0.0.1",
 
   // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
   // timers: "real",

--- a/packages/constants/src/constants.tsx
+++ b/packages/constants/src/constants.tsx
@@ -15,7 +15,7 @@ export const GRAPHQL_HOST =
   process.env.NEXT_PUBLIC_GRAPHQL_HOST ||
   process.env.REACT_APP_GRAPHQL_HOST ||
   (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "") ||
-  "http://localhost:8000";
+  "http://127.0.0.1:8000";
 export const GRAPHQL_BATCHING =
   (process.env.NEXT_PUBLIC_GRAPHQL_BATCHING || process.env.REACT_APP_GRAPHQL_BATCHING) !== "false";
 

--- a/packages/setup-proxy/README.md
+++ b/packages/setup-proxy/README.md
@@ -30,7 +30,7 @@ module.exports = setupProxy({ target: pkg.proxy });
 const { setupProxy, DEFAULT_TARGET, DEFAULT_PROXY_PATHS } = require("@uplift-ltd/setup-proxy");
 
 module.exports = setupProxy({
-  target: "http://localhost:8000",
+  target: "http://127.0.0.1:8000",
   proxyPaths: DEFAULT_PROXY_PATHS.filter((proxyPath) => proxyPath.indexOf("logout") !== -1),
 });
 ```

--- a/packages/setup-proxy/__tests__/setupProxy.test.ts
+++ b/packages/setup-proxy/__tests__/setupProxy.test.ts
@@ -21,10 +21,10 @@ describe("setupProxy", () => {
   it("should fall back to defaults if callback returns partial result", () => {
     const app = { use: jest.fn() };
 
-    setupProxy({ target: "http://localhost:3000" })(app as any);
+    setupProxy({ target: "http://127.0.0.1:3000" })(app as any);
 
     expect(createProxyMiddleware).toHaveBeenCalledWith(DEFAULT_PROXY_PATHS, {
-      target: "http://localhost:3000",
+      target: "http://127.0.0.1:3000",
       changeOrigin: true,
     });
   });

--- a/packages/setup-proxy/src/constants.ts
+++ b/packages/setup-proxy/src/constants.ts
@@ -1,6 +1,6 @@
 import { GRAPHQL_HOST } from "@uplift-ltd/constants";
 
-export const DEFAULT_TARGET = GRAPHQL_HOST || "http://localhost:8000";
+export const DEFAULT_TARGET = GRAPHQL_HOST || "http://127.0.0.1:8000";
 
 export const LOGOUT_URL =
   process.env.NEXT_PUBLIC_LOGOUT_URL || process.env.REACT_APP_LOGOUT_URL || "/logout";

--- a/packages/strings/src/urls.ts
+++ b/packages/strings/src/urls.ts
@@ -112,6 +112,7 @@ export const replaceTokens = <UrlTemplate extends string, TokensMap = UrlTokensM
 function defaultGetAbsoluteUrlHttpSetting(url: string) {
   if (url.includes("localhost")) return false;
   if (url.includes("127.0.0.1")) return false;
+  if (url.includes("::1")) return false;
   if (process.env.NODE_ENV !== "production") return false;
   if (process.env.ENV === "local") return false;
 

--- a/website/docs/packages/setup-proxy.md
+++ b/website/docs/packages/setup-proxy.md
@@ -32,7 +32,7 @@ module.exports = setupProxy({ target: pkg.proxy });
 const { setupProxy, DEFAULT_TARGET, DEFAULT_PROXY_PATHS } = require("@uplift-ltd/setup-proxy");
 
 module.exports = setupProxy({
-  target: "http://localhost:8000",
+  target: "http://127.0.0.1:8000",
   proxyPaths: DEFAULT_PROXY_PATHS.filter((proxyPath) => proxyPath.indexOf("logout") !== -1),
 });
 ```


### PR DESCRIPTION
After updating to node18, localhost will resolve to `::1` in node, which fails for many local development environments. Specifying the ipv4 ip instead of localhost will avoid the DNS resolution which could result in `::1`