### PR TITLE
feat!: add transition options to updateRouterQuery

### DIFF
--- a/packages/nextjs-use-react-navigation/src/useRouterQuery.ts
+++ b/packages/nextjs-use-react-navigation/src/useRouterQuery.ts
@@ -30,6 +30,11 @@ export type RouterQueryResult<
           }
     );
 
+interface NextTransitionOptions {
+  scroll?: boolean;
+  shallow?: boolean;
+}
+
 /**
  * Access to the routerQuery object as well as a callback that makes it easy to modify the
  * querystring from a component.
@@ -42,14 +47,30 @@ export function useRouterQuery<
   const routerNavigation = useRouterNavigation();
 
   const updateRouterQuery = useCallback(
-    (newQuery: UpdateQueryShape) => {
-      routerNavigation.replace({
-        pathname: routerNavigation.pathname,
-        query: {
-          ...routerNavigation.query,
-          ...newQuery,
-        },
+    (
+      newQuery: UpdateQueryShape,
+      { scroll = false, shallow = true }: NextTransitionOptions = {}
+    ) => {
+      const query = {
+        ...routerNavigation.query,
+        ...newQuery,
+      };
+      Object.keys(query).forEach((key) => {
+        if (query[key] === undefined) {
+          delete query[key];
+        }
       });
+      routerNavigation.replace(
+        {
+          pathname: routerNavigation.pathname,
+          query,
+        },
+        undefined,
+        {
+          scroll,
+          shallow,
+        }
+      );
     },
     [routerNavigation]
   );


### PR DESCRIPTION
Adds transition options to updateRouterQuery. It defaults to scroll false (opposite of next.js default) and shallow: true (also opposite). 

Also deleted undefined values instead of having empty query params.

Shallow is to:
> Update the path of the current page without rerunning [getStaticProps](https://nextjs.org/docs/basic-features/data-fetching/get-static-props), [getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props) or [getInitialProps](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props)
