### PR TITLE
fix: Fix https resolution

### DIFF
--- a/packages/strings/__tests__/urls.test.ts
+++ b/packages/strings/__tests__/urls.test.ts
@@ -247,6 +247,23 @@ test("Test absolute URLs", () => {
     "https://test.uplift.ltd/users/3213?term=test"
   );
 
+  expect(
+    makeAbsoluteUrl(
+      USERS_URL,
+      { userId: 3213 },
+      {},
+      { absoluteUrl: { host: "http://localhost:8000" } }
+    )
+  ).toBe("http://localhost:8000/users/3213");
+  expect(
+    makeAbsoluteUrl(
+      USERS_URL,
+      { userId: 3213 },
+      { term: "test" },
+      { absoluteUrl: { host: "http://localhost:8000" } }
+    )
+  ).toBe("http://localhost:8000/users/3213?term=test");
+
   const makeAbsoluteUrlWithFunctions = createMakeUrl({
     absoluteUrl: {
       https: (url) => url.length > 25,

--- a/packages/strings/src/urls.ts
+++ b/packages/strings/src/urls.ts
@@ -112,10 +112,10 @@ export const replaceTokens = <
  * some common configurations, defaults to `true`
  *
  */
-function defaultGetAbsoluteUrlHttpSetting(url: string) {
-  if (url.includes("localhost")) return false;
-  if (url.includes("127.0.0.1")) return false;
-  if (url.includes("::1")) return false;
+function defaultGetAbsoluteUrlHttpSetting(_url: string, host: string) {
+  if (host.includes("localhost")) return false;
+  if (host.includes("127.0.0.1")) return false;
+  if (host.includes("::1")) return false;
   if (process.env.NODE_ENV !== "production") return false;
   if (process.env.ENV === "local") return false;
 
@@ -193,7 +193,7 @@ export type MakeUrlAbsoluteUrlOptions = {
    * the protocol will be https or http. Can define as a constant or
    * by passing a callback predicate
    */
-  https?: boolean | ((url: string) => boolean);
+  https?: boolean | ((url: string, host: string) => boolean);
 
   /**
    * What host should be used for the absolute URL? By default
@@ -294,12 +294,12 @@ export function createMakeUrl(defaultOptions: MakeUrlOptions = {}) {
       // We're constructing an absoluteUrl,
       // https and host configuration will be determined by merging any provided options
       // on top of the default callbacks
-      const { https = defaultGetAbsoluteUrlHttpSetting, host = defaultGetAbsoluteUrlHost } =
+      const { host = defaultGetAbsoluteUrlHost, https = defaultGetAbsoluteUrlHttpSetting } =
         typeof absoluteUrl === "boolean" ? DEFAULT_ABSOLUTE_URL_OPTIONS : absoluteUrl;
 
       // these settings can be defined as a constant or by the result of a callback
-      const shouldUseHttps = typeof https === "function" ? https(baseUrl) : https;
       const hostUrl = typeof host === "function" ? host(baseUrl) : host;
+      const shouldUseHttps = typeof https === "function" ? https(baseUrl, hostUrl) : https;
 
       const protocol = shouldUseHttps ? "https" : "http";
 

--- a/packages/strings/src/urls.ts
+++ b/packages/strings/src/urls.ts
@@ -140,6 +140,19 @@ function defaultGetAbsoluteUrlHost() {
 }
 
 /**
+ * ensureHostOnly
+ *
+ * Make sure the URL doesn't have a protocol prefix
+ */
+function ensureHostOnly(url: string) {
+  if (url.startsWith("http")) {
+    return url.replace(/^https?:\/\//, "");
+  }
+
+  return url;
+}
+
+/**
  * Given an object of key/values, returns a properly encoded querystring for appending to a URL after
  * removing any falsey/missing values. Values as arrays will be appended multiple times. If you want to
  * add an array as comma separated, you will need to pass it as a string for the value.
@@ -298,9 +311,8 @@ export function createMakeUrl(defaultOptions: MakeUrlOptions = {}) {
         typeof absoluteUrl === "boolean" ? DEFAULT_ABSOLUTE_URL_OPTIONS : absoluteUrl;
 
       // these settings can be defined as a constant or by the result of a callback
-      const hostUrl = typeof host === "function" ? host(baseUrl) : host;
+      const hostUrl = ensureHostOnly(typeof host === "function" ? host(baseUrl) : host);
       const shouldUseHttps = typeof https === "function" ? https(baseUrl, hostUrl) : https;
-
       const protocol = shouldUseHttps ? "https" : "http";
 
       baseUrl = url.startsWith(protocol) ? url : (`${protocol}://${hostUrl}${baseUrl}` as const);


### PR DESCRIPTION
2 issues with makeUrl,
1. the https predicate callback was getting the URL only, without host, which isn't that useful. So now we're also giving the callback the host value
2. it was possible to pass in a protocol-prefixed host, which was duplicating or incorrectly prefixing the URL with another protocol prefix. Now we ensure that we're only working with the hostname

Fixes #344 