### PR TITLE
fix: polyfill process.env for non-node environments

### DIFF
--- a/packages/constants/src/constants.tsx
+++ b/packages/constants/src/constants.tsx
@@ -1,3 +1,6 @@
+// Polyfill process.env for non-node environments
+const process = "process" in globalThis ? globalThis.process : ({ env: {} } as NodeJS.Process);
+
 // Environment
 export const IS_SSR = typeof window === "undefined";
 export const IS_REACT_NATIVE =

--- a/packages/sentry/src/constants.ts
+++ b/packages/sentry/src/constants.ts
@@ -1,3 +1,6 @@
+// Polyfill process.env for non-node environments
+const process = "process" in globalThis ? globalThis.process : ({ env: {} } as NodeJS.Process);
+
 export const SENTRY_DSN =
   process.env.SENTRY_DSN ||
   process.env.SENTRY_PUBLIC_DSN ||

--- a/packages/setup-proxy/src/constants.ts
+++ b/packages/setup-proxy/src/constants.ts
@@ -1,5 +1,8 @@
 import { GRAPHQL_HOST } from "@uplift-ltd/constants";
 
+// Polyfill process.env for non-node environments
+const process = "process" in globalThis ? globalThis.process : ({ env: {} } as NodeJS.Process);
+
 export const DEFAULT_TARGET = GRAPHQL_HOST || "http://127.0.0.1:8000";
 
 export const LOGOUT_URL =

--- a/packages/strings/src/urls.ts
+++ b/packages/strings/src/urls.ts
@@ -3,6 +3,9 @@ import { notEmpty } from "@uplift-ltd/ts-helpers";
 import { replaceAll } from "./formatters";
 import { safeJoin } from "./safeJoin";
 
+// Polyfill process.env for non-node environments
+const process = "process" in globalThis ? globalThis.process : ({ env: {} } as NodeJS.Process);
+
 const safeJoinWithQuestionMark = safeJoin("?");
 
 /**


### PR DESCRIPTION
fix #348 by installing a process.env polyfill whenever it's used