### PR TITLE
feat: add EXPO_PUBLIC prefixed env vars

### DIFF
--- a/packages/constants/src/constants.tsx
+++ b/packages/constants/src/constants.tsx
@@ -4,44 +4,62 @@ export const IS_REACT_NATIVE =
   typeof navigator !== "undefined" && navigator.product === "ReactNative";
 
 // GitHub Actions
-export const GITHUB_SHA = process.env.GITHUB_SHA || "";
+export const GITHUB_SHA =
+  process.env.GITHUB_SHA ||
+  process.env.NEXT_PUBLIC_GITHUB_SHA ||
+  process.env.EXPO_PUBLIC_GITHUB_SHA ||
+  process.env.REACT_APP_GITHUB_SHA ||
+  "";
 export const GITHUB_RUN_NUMBER = process.env.GITHUB_RUN_NUMBER || "";
 
 // GraphQL / Apollo constants
 export const GRAPHQL_TOKEN =
-  process.env.NEXT_PUBLIC_GRAPHQL_TOKEN || process.env.REACT_APP_GRAPHQL_TOKEN || "GRAPHQL_TOKEN";
+  process.env.NEXT_PUBLIC_GRAPHQL_TOKEN ||
+  process.env.EXPO_PUBLIC_GRAPHQL_TOKEN ||
+  process.env.REACT_APP_GRAPHQL_TOKEN ||
+  "GRAPHQL_TOKEN";
 export const GRAPHQL_HOST =
   process.env.GRAPHQL_HOST ||
   process.env.NEXT_PUBLIC_GRAPHQL_HOST ||
+  process.env.EXPO_PUBLIC_GRAPHQL_HOST ||
   process.env.REACT_APP_GRAPHQL_HOST ||
   (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "") ||
   "http://127.0.0.1:8000";
 export const GRAPHQL_BATCHING =
-  (process.env.NEXT_PUBLIC_GRAPHQL_BATCHING || process.env.REACT_APP_GRAPHQL_BATCHING) !== "false";
+  (process.env.NEXT_PUBLIC_GRAPHQL_BATCHING ||
+    process.env.EXPO_PUBLIC_GRAPHQL_BATCHING ||
+    process.env.REACT_APP_GRAPHQL_BATCHING) !== "false";
 
 export const GRAPHQL_AUTH_ENDPOINT =
   process.env.GRAPHQL_AUTH_ENDPOINT ||
   process.env.NEXT_PUBLIC_GRAPHQL_AUTH_ENDPOINT ||
+  process.env.EXPO_PUBLIC_GRAPHQL_AUTH_ENDPOINT ||
   process.env.REACT_APP_GRAPHQL_AUTH_ENDPOINT ||
   (GRAPHQL_BATCHING ? "/batch/auth/graphql/" : "/auth/graphql/");
 
 export const GRAPHQL_UNAUTH_ENDPOINT =
   process.env.GRAPHQL_UNAUTH_ENDPOINT ||
   process.env.NEXT_PUBLIC_GRAPHQL_UNAUTH_ENDPOINT ||
+  process.env.EXPO_PUBLIC_GRAPHQL_UNAUTH_ENDPOINT ||
   process.env.REACT_APP_GRAPHQL_UNAUTH_ENDPOINT ||
   (GRAPHQL_BATCHING ? "/batch/graphql/" : "/graphql/");
 
 export const GRAPHQL_AUTH_URL =
   process.env.NEXT_PUBLIC_GRAPHQL_AUTH_URL ||
+  process.env.EXPO_PUBLIC_GRAPHQL_AUTH_URL ||
   process.env.REACT_APP_GRAPHQL_AUTH_URL ||
   (IS_SSR || IS_REACT_NATIVE ? `${GRAPHQL_HOST}${GRAPHQL_AUTH_ENDPOINT}` : GRAPHQL_AUTH_ENDPOINT);
 
 export const GRAPHQL_UNAUTH_URL =
   process.env.NEXT_PUBLIC_GRAPHQL_UNAUTH_URL ||
+  process.env.EXPO_PUBLIC_GRAPHQL_UNAUTH_URL ||
   process.env.REACT_APP_GRAPHQL_UNAUTH_URL ||
   (IS_SSR || IS_REACT_NATIVE
     ? `${GRAPHQL_HOST}${GRAPHQL_UNAUTH_ENDPOINT}`
     : GRAPHQL_UNAUTH_ENDPOINT);
 
 export const S3_UPLOAD_URL =
-  process.env.NEXT_PUBLIC_S3_UPLOAD_URL || process.env.REACT_APP_S3_UPLOAD_URL || "/upload/s3/";
+  process.env.NEXT_PUBLIC_S3_UPLOAD_URL ||
+  process.env.EXPO_PUBLIC_S3_UPLOAD_URL ||
+  process.env.REACT_APP_S3_UPLOAD_URL ||
+  "/upload/s3/";

--- a/packages/sentry/src/constants.ts
+++ b/packages/sentry/src/constants.ts
@@ -3,11 +3,17 @@ export const SENTRY_DSN =
   process.env.SENTRY_PUBLIC_DSN ||
   process.env.NODE_SENTRY_PUBLIC_DSN ||
   process.env.NEXT_PUBLIC_SENTRY_DSN ||
+  process.env.EXPO_PUBLIC_SENTRY_DSN ||
   process.env.REACT_APP_SENTRY_PUBLIC_DSN;
 
 export const NORMALIZE_DEPTH = Number(
-  process.env.SENTRY_NORMALIZE_DEPTH || process.env.NEXT_PUBLIC_SENTRY_NORMALIZE_DEPTH || 10
+  process.env.SENTRY_NORMALIZE_DEPTH ||
+    process.env.NEXT_PUBLIC_SENTRY_NORMALIZE_DEPTH ||
+    process.env.EXPO_PUBLIC_SENTRY_NORMALIZE_DEPTH ||
+    10
 );
 
 export const SENTRY_ENVIRONMENT =
-  process.env.SENTRY_ENVIRONMENT || process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
+  process.env.SENTRY_ENVIRONMENT ||
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+  process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;

--- a/packages/setup-proxy/src/constants.ts
+++ b/packages/setup-proxy/src/constants.ts
@@ -3,7 +3,10 @@ import { GRAPHQL_HOST } from "@uplift-ltd/constants";
 export const DEFAULT_TARGET = GRAPHQL_HOST || "http://127.0.0.1:8000";
 
 export const LOGOUT_URL =
-  process.env.NEXT_PUBLIC_LOGOUT_URL || process.env.REACT_APP_LOGOUT_URL || "/logout";
+  process.env.NEXT_PUBLIC_LOGOUT_URL ||
+  process.env.EXPO_PUBLIC_LOGOUT_URL ||
+  process.env.REACT_APP_LOGOUT_URL ||
+  "/logout";
 
 export const DEFAULT_PROXY_PATHS = [
   "/admin/",


### PR DESCRIPTION
Expo natively supports env vars now. This PR adds support for their prefix.

https://docs.expo.dev/guides/environment-variables/