### PR TITLE
fix(strings): remove constants dependency

### DIFF
--- a/packages/strings/package.json
+++ b/packages/strings/package.json
@@ -29,7 +29,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@uplift-ltd/constants": "^1.9.0",
     "@uplift-ltd/ts-helpers": "^2.1.0"
   }
 }

--- a/packages/strings/src/urls.ts
+++ b/packages/strings/src/urls.ts
@@ -1,4 +1,3 @@
-import { GRAPHQL_HOST } from "@uplift-ltd/constants";
 import { notEmpty } from "@uplift-ltd/ts-helpers";
 import { replaceAll } from "./formatters";
 import { safeJoin } from "./safeJoin";
@@ -131,10 +130,6 @@ function defaultGetAbsoluteUrlHttpSetting(_url: string, host: string) {
  */
 function defaultGetAbsoluteUrlHost() {
   if (typeof window !== "undefined") return window.location.host;
-  if (GRAPHQL_HOST) {
-    const hostUrl = new URL(GRAPHQL_HOST);
-    return hostUrl.host;
-  }
 
   return "";
 }


### PR DESCRIPTION
Removes the `GRAPHQL_HOST` default for makeUrl and removes the `@uplift-ltd/constants` which should make the strings package work in remix.