### PR TITLE
ci(publish): add skipVersion input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,10 @@ on:
         type: boolean
         description: "dry run (skip actual publish)"
         default: false
+      skipVersion:
+        type: boolean
+        description: "skip lerna version (re-publish current package.json versions)"
+        default: false
 
 jobs:
   dependencies:
@@ -115,8 +119,9 @@ jobs:
 
       - name: Lerna version
         if:
-          (github.event.inputs.distTag == 'latest' && github.ref == 'refs/heads/main') ||
-          github.event.inputs.distTag == 'prerelease'
+          github.event.inputs.skipVersion != 'true' &&
+          ((github.event.inputs.distTag == 'latest' && github.ref == 'refs/heads/main') ||
+          github.event.inputs.distTag == 'prerelease')
         run: |
           DRY_RUN_FLAG=""
           if [ "$DRY_RUN" == "true" ]; then


### PR DESCRIPTION
## Summary

Gates the \`Lerna version\` step in publish.yml on \`inputs.skipVersion != 'true'\`.

This lets us re-trigger the publish workflow when only the npm publish step failed (e.g. transient auth errors, as happened on [run #25705326413](https://github.com/uplift-ltd/nexus/actions/runs/25705326413)), without \`lerna version\` bumping on top of an already-pushed \`chore(release): publish\` commit.

## Recovery for run #25705326413

After merging:
1. Rotate NPM_TOKEN at npmjs.com (Automation token) and update the repo secret
2. Re-run \`publish\` workflow with \`skipVersion=true\`
3. \`from-package\` mode will publish the existing 4.1.2 versions to npm; tags are already pushed

## Test plan

- [ ] Workflow YAML syntax-checks (GitHub will validate on push)
- [ ] After NPM_TOKEN rotation, run publish with skipVersion=true and confirm 11 packages publish to npm