### PR TITLE
ci(publish): enable npm provenance for published packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,11 @@ jobs:
       name: Production
       url: "https://github.com/uplift-ltd/nexus/releases"
     runs-on: ubuntu-latest
+    # contents: write — lerna version pushes tags / creates GitHub releases
+    # id-token: write — OIDC token for npm provenance attestations
+    permissions:
+      contents: write
+      id-token: write
     needs:
       - build
     steps:
@@ -142,6 +147,8 @@ jobs:
           DIST_TAG: ${{ github.event.inputs.distTag }}
           GRADUATE: ${{ github.event.inputs.graduate }}
 
+      # Provenance is only generated for the public npm registry; GitHub
+      # Packages does not support sigstore attestations, so it stays off below.
       - name: Lerna publish npm
         if: github.event.inputs.dryRun != 'true'
         run: |
@@ -153,6 +160,7 @@ jobs:
             --registry https://registry.npmjs.org $FORCE_FLAG
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
           DIST_TAG: ${{ github.event.inputs.distTag }}
           FORCE_PUBLISH: ${{ github.event.inputs.forcePublish }}
 


### PR DESCRIPTION
## What

  Enable [npm provenance](https://docs.npmjs.com/generating-provenance-statements) attestations for all
  published packages.

  ## Changes (`.github/workflows/publish.yml`)

  - Add job `permissions` to `publish`: `id-token: write` (OIDC token npm uses to mint provenance) and
  `contents: write` (keeps the existing lerna tag-push / GitHub release creation working now that permissions
  are explicit).
  - Set `NPM_CONFIG_PROVENANCE: "true"` on the **npmjs.org** publish step only. Lerna 9 picks this up and
  attaches a sigstore provenance attestation per package.
  - Left off the GitHub Packages publish step — GHP does not support sigstore attestations.

  No `package.json` changes needed: all 22 real packages are already public (`access: public`) with
  `repository.directory` set, which is everything provenance requires.