### PR TITLE
ci(publish): restore packages: write permission for GHP publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,9 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     # contents: write — lerna version pushes tags / creates GitHub releases
     # id-token: write — OIDC token for npm provenance attestations
+    # packages: write — GITHUB_TOKEN publishes to GitHub Packages
     permissions:
       contents: write
       id-token: write
+      packages: write
     needs:
       - build
     steps:


### PR DESCRIPTION
## Summary
- Add `packages: write` to the publish job permissions block

The explicit `permissions:` block added in #461 replaced the default `GITHUB_TOKEN` grants, which silently dropped `packages: write`. The "Lerna publish ghp" step then failed with `E403 Permission installation not allowed to Write organization package` (e.g. run 29850314584). The npm publish step is unaffected and now succeeds via trusted publishing with provenance.

## Test plan
- [ ] Merge, then re-run the publish workflow and confirm the GitHub Packages step succeeds